### PR TITLE
Add @PLT suffix to all function calls

### DIFF
--- a/lib/rucc/gen.rb
+++ b/lib/rucc/gen.rb
@@ -1264,10 +1264,6 @@ module Rucc
       pop("rcx")
     end
 
-    # Functions in shared library
-    # TODO(sout37) Fix this dirty hack.
-    SHARED_LIBRARY_FUNCTIONS  = ["printf", "calloc", "atoi"]
-
     # @param [Node] node
     def emit_func_call(node)
       # TODO(south37) impl SAVE when necessary
@@ -1308,11 +1304,7 @@ module Rucc
       if isptr
         emit("call *#r11")
       else
-        fname = node.fname
-        # Add `@PLT` suffix to functions in shared library here.
-        if SHARED_LIBRARY_FUNCTIONS.include?(fname)
-          fname += "@PLT"
-        end
+        fname = "#{node.fname}@PLT"
         emit("call #{fname}")
       end
       maybe_booleanize_retval(node.ty)

--- a/spec/targets/align.s
+++ b/spec/targets/align.s
@@ -154,7 +154,7 @@ test_alignas:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -180,7 +180,7 @@ test_alignas:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -206,7 +206,7 @@ test_alignas:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -232,7 +232,7 @@ test_alignas:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -268,7 +268,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -293,7 +293,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -318,7 +318,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -343,7 +343,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -368,7 +368,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -393,7 +393,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -418,7 +418,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -443,7 +443,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -468,7 +468,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -493,7 +493,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -518,7 +518,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -543,7 +543,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -568,7 +568,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -606,7 +606,7 @@ test_alignof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -646,7 +646,7 @@ test_constexpr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -673,17 +673,17 @@ testmain:
 	lea .L19(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 42 0
 	#     test_alignof();
-	call test_alignas
+	call test_alignas@PLT
 	.loc 2 43 0
 	#     test_constexpr();
-	call test_alignof
+	call test_alignof@PLT
 	.loc 2 44 0
 	# }
-	call test_constexpr
+	call test_constexpr@PLT
 	leave
 	ret

--- a/spec/targets/arith.s
+++ b/spec/targets/arith.s
@@ -155,7 +155,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -187,7 +187,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -219,7 +219,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -261,7 +261,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -303,7 +303,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -345,7 +345,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -389,7 +389,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -428,7 +428,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -462,7 +462,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -496,7 +496,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -528,7 +528,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -573,7 +573,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -609,7 +609,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -647,7 +647,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -674,7 +674,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -709,7 +709,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -752,7 +752,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -783,7 +783,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -814,7 +814,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -845,7 +845,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -876,7 +876,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -907,7 +907,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -938,7 +938,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -969,7 +969,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1000,7 +1000,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1031,7 +1031,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1062,7 +1062,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1093,7 +1093,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1125,7 +1125,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1157,7 +1157,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1189,7 +1189,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1221,7 +1221,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1258,7 +1258,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1295,7 +1295,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1332,7 +1332,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1369,7 +1369,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1410,7 +1410,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1451,7 +1451,7 @@ test_relative:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1498,7 +1498,7 @@ test_inc_dec:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1529,7 +1529,7 @@ test_inc_dec:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1564,7 +1564,7 @@ test_inc_dec:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1595,7 +1595,7 @@ test_inc_dec:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1628,7 +1628,7 @@ test_inc_dec:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1659,7 +1659,7 @@ test_inc_dec:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1692,7 +1692,7 @@ test_inc_dec:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1723,7 +1723,7 @@ test_inc_dec:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1763,7 +1763,7 @@ test_bool:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1791,7 +1791,7 @@ test_bool:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1839,7 +1839,7 @@ test_ternary:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1876,7 +1876,7 @@ test_ternary:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1919,7 +1919,7 @@ test_ternary:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1962,7 +1962,7 @@ test_ternary:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1993,7 +1993,7 @@ test_ternary:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2029,7 +2029,7 @@ test_ternary:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2094,7 +2094,7 @@ test_unary:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2137,7 +2137,7 @@ test_unary:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2178,7 +2178,7 @@ test_unary:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2216,7 +2216,7 @@ test_comma:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2261,7 +2261,7 @@ test_comma:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2288,29 +2288,29 @@ testmain:
 	lea .L77(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 93 0
 	#     test_relative();
-	call test_basic
+	call test_basic@PLT
 	.loc 2 94 0
 	#     test_inc_dec();
-	call test_relative
+	call test_relative@PLT
 	.loc 2 95 0
 	#     test_bool();
-	call test_inc_dec
+	call test_inc_dec@PLT
 	.loc 2 96 0
 	#     test_unary();
-	call test_bool
+	call test_bool@PLT
 	.loc 2 97 0
 	#     test_ternary();
-	call test_unary
+	call test_unary@PLT
 	.loc 2 98 0
 	#     test_comma();
-	call test_ternary
+	call test_ternary@PLT
 	.loc 2 99 0
 	# }
-	call test_comma
+	call test_comma@PLT
 	leave
 	ret

--- a/spec/targets/array.s
+++ b/spec/targets/array.s
@@ -177,7 +177,7 @@ t1:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -275,7 +275,7 @@ t2:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -366,7 +366,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -423,7 +423,7 @@ t4:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -462,7 +462,7 @@ t4:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -501,7 +501,7 @@ t4:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -620,7 +620,7 @@ t5:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -659,7 +659,7 @@ t5:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -724,7 +724,7 @@ t6a:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -780,7 +780,7 @@ t6:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call t6a
+	call t6a@PLT
 	pop %rsi
 	pop %rdi
 	leave
@@ -853,7 +853,7 @@ t7:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -880,29 +880,29 @@ testmain:
 	lea .L10(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 63 0
 	#     t2();
-	call t1
+	call t1@PLT
 	.loc 2 64 0
 	#     t3();
-	call t2
+	call t2@PLT
 	.loc 2 65 0
 	#     t4();
-	call t3
+	call t3@PLT
 	.loc 2 66 0
 	#     t5();
-	call t4
+	call t4@PLT
 	.loc 2 67 0
 	#     t6();
-	call t5
+	call t5@PLT
 	.loc 2 68 0
 	#     t7();
-	call t6
+	call t6@PLT
 	.loc 2 69 0
 	# }
-	call t7
+	call t7@PLT
 	leave
 	ret

--- a/spec/targets/assign.s
+++ b/spec/targets/assign.s
@@ -143,7 +143,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 8 0
@@ -188,7 +188,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -231,7 +231,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -274,7 +274,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -318,7 +318,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -363,7 +363,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -410,7 +410,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -452,7 +452,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -495,7 +495,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -538,7 +538,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -581,7 +581,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -632,7 +632,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -678,7 +678,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -724,7 +724,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -771,7 +771,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -819,7 +819,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -870,7 +870,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -915,7 +915,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -961,7 +961,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1007,7 +1007,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1053,7 +1053,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/bitop.s
+++ b/spec/targets/bitop.s
@@ -157,7 +157,7 @@ test_or:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -186,7 +186,7 @@ test_or:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -215,7 +215,7 @@ test_or:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -255,7 +255,7 @@ test_and:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -284,7 +284,7 @@ test_and:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -326,7 +326,7 @@ test_not:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -357,7 +357,7 @@ test_not:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -388,7 +388,7 @@ test_not:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -429,7 +429,7 @@ test_xor:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -470,7 +470,7 @@ test_shift:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -500,7 +500,7 @@ test_shift:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -530,7 +530,7 @@ test_shift:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -560,7 +560,7 @@ test_shift:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -596,7 +596,7 @@ test_shift:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -622,23 +622,23 @@ testmain:
 	lea .L14(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 38 0
 	#     test_and();
-	call test_or
+	call test_or@PLT
 	.loc 2 39 0
 	#     test_not();
-	call test_and
+	call test_and@PLT
 	.loc 2 40 0
 	#     test_xor();
-	call test_not
+	call test_not@PLT
 	.loc 2 41 0
 	#     test_shift();
-	call test_xor
+	call test_xor@PLT
 	.loc 2 42 0
 	# }
-	call test_shift
+	call test_shift@PLT
 	leave
 	ret

--- a/spec/targets/builtin.s
+++ b/spec/targets/builtin.s
@@ -182,14 +182,14 @@ test_return_address_sub1:
 	pop %r11
 	push %rax
 	sub $8, %rsp
-	call test_return_address_sub2
+	call test_return_address_sub2@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -226,7 +226,7 @@ test_return_address:
 	#     ptr = test_return_address_sub1();
 	.L0:
 	sub $8, %rsp
-	call test_return_address_sub1
+	call test_return_address_sub1@PLT
 	add $8, %rsp
 	mov %rax, -8(%rbp)
 	.loc 2 23 0
@@ -282,7 +282,7 @@ test_return_address:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -309,11 +309,11 @@ testmain:
 	lea .L11(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 33 0
 	# }
-	call test_return_address
+	call test_return_address@PLT
 	leave
 	ret

--- a/spec/targets/cast.s
+++ b/spec/targets/cast.s
@@ -181,7 +181,7 @@ test_signedcast:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -244,7 +244,7 @@ test_unsignedcast:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -271,7 +271,7 @@ testmain:
 	lea .L2(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 3 22 0
@@ -304,7 +304,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -341,7 +341,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -379,7 +379,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -444,16 +444,16 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
 	.loc 2 29 0
 	#     test_unsignedcast();
-	call test_signedcast
+	call test_signedcast@PLT
 	.loc 2 30 0
 	# }
-	call test_unsignedcast
+	call test_unsignedcast@PLT
 	leave
 	ret

--- a/spec/targets/comp.s
+++ b/spec/targets/comp.s
@@ -142,7 +142,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	pop %rdi
 	.file 3 "/home/vagrant/rucc/spec/targets/test.h"
 	.loc 3 20 0
@@ -174,7 +174,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -207,7 +207,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -240,7 +240,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -273,7 +273,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -306,7 +306,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -339,7 +339,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -372,7 +372,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -405,7 +405,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -438,7 +438,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -471,7 +471,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -504,7 +504,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -537,7 +537,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -583,7 +583,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -628,7 +628,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -671,7 +671,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -714,7 +714,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -757,7 +757,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -800,7 +800,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -843,7 +843,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -886,7 +886,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -929,7 +929,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -973,7 +973,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1017,7 +1017,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1061,7 +1061,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1105,7 +1105,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx

--- a/spec/targets/constexpr.s
+++ b/spec/targets/constexpr.s
@@ -166,7 +166,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.file 3 "/home/vagrant/rucc/spec/targets/test.h"
@@ -196,7 +196,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -227,7 +227,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -273,7 +273,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/control.s
+++ b/spec/targets/control.s
@@ -436,14 +436,14 @@ test_if:
 	mov $97, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if1
+	call test_if1@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -463,14 +463,14 @@ test_if:
 	mov $98, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if2
+	call test_if2@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -490,14 +490,14 @@ test_if:
 	mov $99, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if3
+	call test_if3@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -517,14 +517,14 @@ test_if:
 	mov $100, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if4
+	call test_if4@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -544,14 +544,14 @@ test_if:
 	mov $101, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if5
+	call test_if5@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -571,14 +571,14 @@ test_if:
 	mov $102, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if6
+	call test_if6@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -598,14 +598,14 @@ test_if:
 	mov $103, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if7
+	call test_if7@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -625,14 +625,14 @@ test_if:
 	mov $104, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if8
+	call test_if8@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -652,14 +652,14 @@ test_if:
 	mov $105, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if9
+	call test_if9@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -679,14 +679,14 @@ test_if:
 	mov $106, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if10
+	call test_if10@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -706,14 +706,14 @@ test_if:
 	mov $107, %rax
 	push %rax
 	sub $8, %rsp
-	call test_if11
+	call test_if11@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -817,7 +817,7 @@ test_for:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -912,7 +912,7 @@ test_for:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1058,7 +1058,7 @@ test_for:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1109,7 +1109,7 @@ test_for:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1245,7 +1245,7 @@ test_for:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1333,7 +1333,7 @@ test_while:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1418,7 +1418,7 @@ test_while:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1550,7 +1550,7 @@ test_while:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1651,7 +1651,7 @@ test_while:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1736,7 +1736,7 @@ test_do:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1784,7 +1784,7 @@ test_do:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1911,7 +1911,7 @@ test_do:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2052,7 +2052,7 @@ test_do:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2143,7 +2143,7 @@ test_switch:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call ffail
+	call ffail@PLT
 	add $8, %rsp
 	pop %rdx
 	pop %rsi
@@ -2179,7 +2179,7 @@ test_switch:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call ffail
+	call ffail@PLT
 	add $8, %rsp
 	pop %rdx
 	pop %rsi
@@ -2211,7 +2211,7 @@ test_switch:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2392,7 +2392,7 @@ test_switch:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2460,7 +2460,7 @@ test_switch:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2516,7 +2516,7 @@ test_switch:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2618,7 +2618,7 @@ test_switch:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call ffail
+	call ffail@PLT
 	add $8, %rsp
 	pop %rdx
 	pop %rsi
@@ -2647,7 +2647,7 @@ test_switch:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call ffail
+	call ffail@PLT
 	add $8, %rsp
 	pop %rdx
 	pop %rsi
@@ -2680,7 +2680,7 @@ test_switch:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call ffail
+	call ffail@PLT
 	add $8, %rsp
 	pop %rdx
 	pop %rsi
@@ -2938,7 +2938,7 @@ test_switch:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2996,7 +2996,7 @@ test_goto:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3092,7 +3092,7 @@ test_goto:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3162,7 +3162,7 @@ test_label:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3207,7 +3207,7 @@ test_label:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3340,7 +3340,7 @@ test_label:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3405,7 +3405,7 @@ test_computed_goto:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3504,7 +3504,7 @@ test_computed_goto:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3574,7 +3574,7 @@ test_logor:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3608,7 +3608,7 @@ test_logor:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3642,7 +3642,7 @@ test_logor:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3668,35 +3668,35 @@ testmain:
 	lea .L228(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 274 0
 	#     test_for();
-	call test_if
+	call test_if@PLT
 	.loc 2 275 0
 	#     test_while();
-	call test_for
+	call test_for@PLT
 	.loc 2 276 0
 	#     test_do();
-	call test_while
+	call test_while@PLT
 	.loc 2 277 0
 	#     test_switch();
-	call test_do
+	call test_do@PLT
 	.loc 2 278 0
 	#     test_goto();
-	call test_switch
+	call test_switch@PLT
 	.loc 2 279 0
 	#     test_label();
-	call test_goto
+	call test_goto@PLT
 	.loc 2 280 0
 	#     test_computed_goto();
-	call test_label
+	call test_label@PLT
 	.loc 2 281 0
 	#     test_logor();
-	call test_computed_goto
+	call test_computed_goto@PLT
 	.loc 2 282 0
 	# }
-	call test_logor
+	call test_logor@PLT
 	leave
 	ret

--- a/spec/targets/conversion.s
+++ b/spec/targets/conversion.s
@@ -167,7 +167,7 @@ test_bool:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -211,7 +211,7 @@ test_bool:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -264,7 +264,7 @@ test_bool:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -317,7 +317,7 @@ test_bool:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -374,7 +374,7 @@ test_float:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -401,14 +401,14 @@ testmain:
 	lea .L7(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 24 0
 	#     test_float();
-	call test_bool
+	call test_bool@PLT
 	.loc 2 25 0
 	# }
-	call test_float
+	call test_float@PLT
 	leave
 	ret

--- a/spec/targets/decl.s
+++ b/spec/targets/decl.s
@@ -167,7 +167,7 @@ t1:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -240,7 +240,7 @@ t2:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -291,7 +291,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -352,7 +352,7 @@ t4:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -415,7 +415,7 @@ t5:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -462,7 +462,7 @@ t6:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -494,26 +494,26 @@ testmain:
 	lea .L6(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 46 0
 	#     t2();
-	call t1
+	call t1@PLT
 	.loc 2 47 0
 	#     t3();
-	call t2
+	call t2@PLT
 	.loc 2 48 0
 	#     t4();
-	call t3
+	call t3@PLT
 	.loc 2 49 0
 	#     t5();
-	call t4
+	call t4@PLT
 	.loc 2 50 0
 	#     t6();
-	call t5
+	call t5@PLT
 	.loc 2 51 0
 	# }
-	call t6
+	call t6@PLT
 	leave
 	ret

--- a/spec/targets/enum.s
+++ b/spec/targets/enum.s
@@ -146,7 +146,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.file 3 "/home/vagrant/rucc/spec/targets/test.h"
@@ -174,7 +174,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -203,7 +203,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -234,7 +234,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -263,7 +263,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -295,7 +295,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -324,7 +324,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/extern.s
+++ b/spec/targets/extern.s
@@ -142,7 +142,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.file 3 "/home/vagrant/rucc/spec/targets/test.h"
@@ -170,7 +170,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -199,7 +199,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/float.s
+++ b/spec/targets/float.s
@@ -273,7 +273,7 @@ recursive:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call recursive
+	call recursive@PLT
 	add $8, %rsp
 	leave
 	ret
@@ -347,7 +347,7 @@ fmt:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call vsnprintf
+	call vsnprintf@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -389,7 +389,7 @@ fmtint:
 	pop %rsi
 	pop %rdi
 	mov $0, %eax
-	call fmt
+	call fmt@PLT
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
@@ -423,7 +423,7 @@ fmtdbl:
 	add $8, %rsp
 	pop %rdi
 	mov $1, %eax
-	call fmt
+	call fmt@PLT
 	pop %rdi
 	leave
 	ret
@@ -464,14 +464,14 @@ std:
 	mov $21, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -500,14 +500,14 @@ std:
 	mov $0, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -536,14 +536,14 @@ std:
 	mov $2, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -572,14 +572,14 @@ std:
 	mov $1, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -608,14 +608,14 @@ std:
 	mov $6, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -650,14 +650,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -686,14 +686,14 @@ std:
 	mov $24, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -728,14 +728,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -764,14 +764,14 @@ std:
 	mov $38, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -800,14 +800,14 @@ std:
 	mov $128, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -842,14 +842,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -883,14 +883,14 @@ std:
 	sub %rcx, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -924,14 +924,14 @@ std:
 	sub %rcx, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -970,7 +970,7 @@ std:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -1006,14 +1006,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1042,14 +1042,14 @@ std:
 	mov $15, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1084,14 +1084,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1120,14 +1120,14 @@ std:
 	mov $53, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1162,14 +1162,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1198,14 +1198,14 @@ std:
 	mov $308, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1234,14 +1234,14 @@ std:
 	mov $1024, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1276,14 +1276,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1317,14 +1317,14 @@ std:
 	sub %rcx, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1358,14 +1358,14 @@ std:
 	sub %rcx, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1404,7 +1404,7 @@ std:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -1440,14 +1440,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1476,14 +1476,14 @@ std:
 	mov $15, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1518,14 +1518,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1554,14 +1554,14 @@ std:
 	mov $53, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1596,14 +1596,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1632,14 +1632,14 @@ std:
 	mov $308, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1668,14 +1668,14 @@ std:
 	mov $1024, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1710,14 +1710,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1751,14 +1751,14 @@ std:
 	sub %rcx, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1792,14 +1792,14 @@ std:
 	sub %rcx, %rax
 	push %rax
 	pop %rdi
-	call fmtint
+	call fmtint@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1838,7 +1838,7 @@ std:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -1874,14 +1874,14 @@ std:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call fmtdbl
+	call fmtdbl@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1909,12 +1909,12 @@ testmain:
 	lea .L93(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 80 0
 	# 
-	call std
+	call std@PLT
 	.loc 3 20 0
 	# #define expect_string(a, b) fexpect_string(__FILE__, __LINE__, a, b);
 	push %rdi
@@ -1947,7 +1947,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2001,7 +2001,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2041,7 +2041,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2094,7 +2094,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2133,7 +2133,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2176,7 +2176,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2228,7 +2228,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2280,7 +2280,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2332,7 +2332,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2384,7 +2384,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2433,7 +2433,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2482,7 +2482,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2531,7 +2531,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2580,7 +2580,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2618,7 +2618,7 @@ testmain:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call tf1
+	call tf1@PLT
 	add $8, %rsp
 	sub $8, %rsp
 	movsd %xmm0, (%rsp)
@@ -2628,7 +2628,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2662,7 +2662,7 @@ testmain:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call tf1
+	call tf1@PLT
 	add $8, %rsp
 	sub $8, %rsp
 	movsd %xmm0, (%rsp)
@@ -2672,7 +2672,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2709,7 +2709,7 @@ testmain:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call tf2
+	call tf2@PLT
 	add $8, %rsp
 	sub $8, %rsp
 	movsd %xmm0, (%rsp)
@@ -2719,7 +2719,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2753,7 +2753,7 @@ testmain:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call tf2
+	call tf2@PLT
 	add $8, %rsp
 	sub $8, %rsp
 	movsd %xmm0, (%rsp)
@@ -2763,7 +2763,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2799,7 +2799,7 @@ testmain:
 	cvttsd2si %xmm0, %eax
 	push %rax
 	pop %rdi
-	call tf3
+	call tf3@PLT
 	pop %rdi
 	sub $8, %rsp
 	movsd %xmm0, (%rsp)
@@ -2809,7 +2809,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2840,7 +2840,7 @@ testmain:
 	mov $10, %rax
 	push %rax
 	pop %rdi
-	call tf3
+	call tf3@PLT
 	pop %rdi
 	sub $8, %rsp
 	movsd %xmm0, (%rsp)
@@ -2850,7 +2850,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2889,7 +2889,7 @@ testmain:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call tf1
+	call tf1@PLT
 	add $8, %rsp
 	cvtps2pd %xmm0, %xmm0
 	sub $8, %rsp
@@ -2900,7 +2900,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2933,7 +2933,7 @@ testmain:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call tf1
+	call tf1@PLT
 	add $8, %rsp
 	cvtps2pd %xmm0, %xmm0
 	sub $8, %rsp
@@ -2944,7 +2944,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2980,7 +2980,7 @@ testmain:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call tf2
+	call tf2@PLT
 	add $8, %rsp
 	cvtps2pd %xmm0, %xmm0
 	sub $8, %rsp
@@ -2991,7 +2991,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -3024,7 +3024,7 @@ testmain:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call tf2
+	call tf2@PLT
 	add $8, %rsp
 	cvtps2pd %xmm0, %xmm0
 	sub $8, %rsp
@@ -3035,7 +3035,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -3070,7 +3070,7 @@ testmain:
 	cvttsd2si %xmm0, %eax
 	push %rax
 	pop %rdi
-	call tf3
+	call tf3@PLT
 	pop %rdi
 	cvtps2pd %xmm0, %xmm0
 	sub $8, %rsp
@@ -3081,7 +3081,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -3111,7 +3111,7 @@ testmain:
 	mov $10, %rax
 	push %rax
 	pop %rdi
-	call tf3
+	call tf3@PLT
 	pop %rdi
 	cvtps2pd %xmm0, %xmm0
 	sub $8, %rsp
@@ -3122,7 +3122,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -3155,7 +3155,7 @@ testmain:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call recursive
+	call recursive@PLT
 	add $8, %rsp
 	sub $8, %rsp
 	movsd %xmm0, (%rsp)
@@ -3165,7 +3165,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp

--- a/spec/targets/funcargs.s
+++ b/spec/targets/funcargs.s
@@ -168,7 +168,7 @@ many_ints:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -199,7 +199,7 @@ many_ints:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -230,7 +230,7 @@ many_ints:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -261,7 +261,7 @@ many_ints:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -292,7 +292,7 @@ many_ints:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -323,7 +323,7 @@ many_ints:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -354,7 +354,7 @@ many_ints:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -385,7 +385,7 @@ many_ints:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -416,7 +416,7 @@ many_ints:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -494,7 +494,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -528,7 +528,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -562,7 +562,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -596,7 +596,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -630,7 +630,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -664,7 +664,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -698,7 +698,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -732,7 +732,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -766,7 +766,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -800,7 +800,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -834,7 +834,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -868,7 +868,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -902,7 +902,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -936,7 +936,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -970,7 +970,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -1004,7 +1004,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -1038,7 +1038,7 @@ many_floats:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -1160,7 +1160,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1190,7 +1190,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1229,7 +1229,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1259,7 +1259,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1298,7 +1298,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1328,7 +1328,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1367,7 +1367,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1397,7 +1397,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1436,7 +1436,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1466,7 +1466,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1505,7 +1505,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1535,7 +1535,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1574,7 +1574,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1604,7 +1604,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1643,7 +1643,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1673,7 +1673,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1712,7 +1712,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1742,7 +1742,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1781,7 +1781,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1811,7 +1811,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1850,7 +1850,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1880,7 +1880,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1919,7 +1919,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1949,7 +1949,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1988,7 +1988,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2018,7 +2018,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2057,7 +2057,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2087,7 +2087,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2126,7 +2126,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2156,7 +2156,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2195,7 +2195,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2225,7 +2225,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2264,7 +2264,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2294,7 +2294,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2333,7 +2333,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2363,7 +2363,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2402,7 +2402,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2432,7 +2432,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2471,7 +2471,7 @@ mixed:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -2501,7 +2501,7 @@ mixed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2527,7 +2527,7 @@ testmain:
 	lea .L86(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 42 0
@@ -2562,7 +2562,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call many_ints
+	call many_ints@PLT
 	add $24, %rsp
 	pop %r9
 	pop %r8
@@ -2739,7 +2739,7 @@ testmain:
 	add $8, %rsp
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call many_floats
+	call many_floats@PLT
 	add $72, %rsp
 	add $8, %rsp
 	movsd (%rsp), %xmm7
@@ -3001,7 +3001,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call mixed
+	call mixed@PLT
 	add $208, %rsp
 	add $8, %rsp
 	movsd (%rsp), %xmm7

--- a/spec/targets/function.s
+++ b/spec/targets/function.s
@@ -171,7 +171,7 @@ t2:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -216,7 +216,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -245,7 +245,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -274,7 +274,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -303,7 +303,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -332,7 +332,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -361,7 +361,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -421,14 +421,14 @@ t4:
 	lea -8(%rbp), %rax
 	push %rax
 	pop %rdi
-	call t4a
+	call t4a@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -471,7 +471,7 @@ t5a:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -520,7 +520,7 @@ t5a:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -569,7 +569,7 @@ t5a:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -612,7 +612,7 @@ t5b:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -661,7 +661,7 @@ t5b:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -710,7 +710,7 @@ t5b:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -810,7 +810,7 @@ t5:
 	lea -16(%rbp), %rax
 	push %rax
 	pop %rdi
-	call t5a
+	call t5a@PLT
 	pop %rdi
 	.loc 2 51 0
 	# }
@@ -820,7 +820,7 @@ t5:
 	lea -16(%rbp), %rax
 	push %rax
 	pop %rdi
-	call t5b
+	call t5b@PLT
 	pop %rdi
 	leave
 	ret
@@ -910,7 +910,7 @@ t8:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1083,7 +1083,7 @@ func_ptr_call:
 	movsd %xmm0, (%rsp)
 	movsd (%rsp), %xmm0
 	add $8, %rsp
-	call ptrtest3
+	call ptrtest3@PLT
 	add $8, %rsp
 	sub $8, %rsp
 	movsd %xmm0, (%rsp)
@@ -1093,7 +1093,7 @@ func_ptr_call:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1132,7 +1132,7 @@ func_ptr_call:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1175,7 +1175,7 @@ func_ptr_call:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1227,7 +1227,7 @@ func_ptr_call:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1266,7 +1266,7 @@ func_ptr_call:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1296,7 +1296,7 @@ func_ptr_call:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call ptrtest4
+	call ptrtest4@PLT
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
@@ -1305,7 +1305,7 @@ func_ptr_call:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1351,7 +1351,7 @@ func_name:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1384,7 +1384,7 @@ func_name:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1504,14 +1504,14 @@ local_static:
 	mov $6, %rax
 	push %rax
 	sub $8, %rsp
-	call local_static2
+	call local_static2@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1531,21 +1531,21 @@ local_static:
 	mov $7, %rax
 	push %rax
 	sub $8, %rsp
-	call local_static2
+	call local_static2@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
 	.loc 2 128 0
 	#     expect(8, local_static2());
-	call local_static3
+	call local_static3@PLT
 	.loc 3 20 0
 	# #define expect_string(a, b) fexpect_string(__FILE__, __LINE__, a, b);
 	push %rdi
@@ -1563,14 +1563,14 @@ local_static:
 	mov $8, %rax
 	push %rax
 	sub $8, %rsp
-	call local_static2
+	call local_static2@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1642,14 +1642,14 @@ test_bool:
 	mov $256, %rax
 	push %rax
 	pop %rdi
-	call booltest1
+	call booltest1@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1672,14 +1672,14 @@ test_bool:
 	mov $257, %rax
 	push %rax
 	pop %rdi
-	call booltest1
+	call booltest1@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1702,7 +1702,7 @@ test_bool:
 	mov $512, %rax
 	push %rax
 	pop %rdi
-	call booltest2
+	call booltest2@PLT
 	movzx %al, %rax
 	pop %rdi
 	movsbq %al, %rax
@@ -1711,7 +1711,7 @@ test_bool:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1734,7 +1734,7 @@ test_bool:
 	mov $513, %rax
 	push %rax
 	pop %rdi
-	call booltest2
+	call booltest2@PLT
 	movzx %al, %rax
 	pop %rdi
 	movsbq %al, %rax
@@ -1743,7 +1743,7 @@ test_bool:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1830,7 +1830,7 @@ test_struct:
 	mov %r11, 8(%rsp)
 	mov -8(%rsp), %rcx
 	mov -16(%rsp), %r11
-	call sum
+	call sum@PLT
 	add $16, %rsp
 	add $8, %rsp
 	push %rax
@@ -1838,7 +1838,7 @@ test_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1900,7 +1900,7 @@ testmain:
 	lea .L35(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 3 20 0
@@ -1920,14 +1920,14 @@ testmain:
 	mov $77, %rax
 	push %rax
 	sub $8, %rsp
-	call t1
+	call t1@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1939,7 +1939,7 @@ testmain:
 	mov $79, %rax
 	push %rax
 	pop %rdi
-	call t2
+	call t2@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 185 0
@@ -1968,7 +1968,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call t3
+	call t3@PLT
 	pop %r9
 	pop %r8
 	pop %rcx
@@ -1977,10 +1977,10 @@ testmain:
 	pop %rdi
 	.loc 2 186 0
 	#     t5();
-	call t4
+	call t4@PLT
 	.loc 2 187 0
 	#     expect(3, t6());
-	call t5
+	call t5@PLT
 	.loc 3 20 0
 	# #define expect_string(a, b) fexpect_string(__FILE__, __LINE__, a, b);
 	push %rdi
@@ -1998,14 +1998,14 @@ testmain:
 	mov $3, %rax
 	push %rax
 	sub $8, %rsp
-	call t6
+	call t6@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2033,7 +2033,7 @@ testmain:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call t7
+	call t7@PLT
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
@@ -2042,7 +2042,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2079,7 +2079,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2116,7 +2116,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2129,12 +2129,12 @@ testmain:
 	push %rax
 	pop %rdi
 	mov $0, %eax
-	call t8
+	call t8@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 193 0
 	#     expect(7, t10(3, 4.0));
-	call t9
+	call t9@PLT
 	.loc 3 20 0
 	# #define expect_string(a, b) fexpect_string(__FILE__, __LINE__, a, b);
 	push %rdi
@@ -2164,42 +2164,42 @@ testmain:
 	movsd (%rsp), %xmm0
 	add $8, %rsp
 	pop %rdi
-	call t10
+	call t10@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
 	.loc 2 195 0
 	#     func_name();
-	call func_ptr_call
+	call func_ptr_call@PLT
 	.loc 2 196 0
 	#     local_static();
-	call func_name
+	call func_name@PLT
 	.loc 2 197 0
 	#     empty();
-	call local_static
+	call local_static@PLT
 	.loc 2 198 0
 	#     empty2();
-	call empty
+	call empty@PLT
 	.loc 2 199 0
 	#     test_bool();
-	call empty2
+	call empty2@PLT
 	.loc 2 200 0
 	#     test_struct();
-	call test_bool
+	call test_bool@PLT
 	.loc 2 201 0
 	#     test_funcdesg();
-	call test_struct
+	call test_struct@PLT
 	.loc 2 202 0
 	#     expect(3, retfunc()());
-	call test_funcdesg
+	call test_funcdesg@PLT
 	.loc 3 20 0
 	# #define expect_string(a, b) fexpect_string(__FILE__, __LINE__, a, b);
 	push %rdi
@@ -2217,7 +2217,7 @@ testmain:
 	mov $3, %rax
 	push %rax
 	sub $8, %rsp
-	call retfunc
+	call retfunc@PLT
 	push %rax
 	pop %r11
 	call *%r11
@@ -2227,7 +2227,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2247,7 +2247,7 @@ testmain:
 	mov $3, %rax
 	push %rax
 	sub $8, %rsp
-	call retfunc2
+	call retfunc2@PLT
 	push %rax
 	pop %r11
 	call *%r11
@@ -2257,7 +2257,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/global.s
+++ b/spec/targets/global.s
@@ -210,7 +210,7 @@ testmain:
 	lea .L3(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 24 0
@@ -243,7 +243,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -272,7 +272,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -306,7 +306,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -337,7 +337,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -399,7 +399,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -438,7 +438,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -477,7 +477,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -506,7 +506,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -540,7 +540,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -569,7 +569,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -598,7 +598,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -632,7 +632,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -665,7 +665,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -698,7 +698,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -728,7 +728,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpectl
+	call fexpectl@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -761,7 +761,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpectl
+	call fexpectl@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/import.s
+++ b/spec/targets/import.s
@@ -140,7 +140,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	leave

--- a/spec/targets/includeguard.s
+++ b/spec/targets/includeguard.s
@@ -140,7 +140,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	leave

--- a/spec/targets/initializer.s
+++ b/spec/targets/initializer.s
@@ -203,7 +203,7 @@ verify:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -300,7 +300,7 @@ verify_short:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -366,7 +366,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -407,7 +407,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -448,7 +448,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -504,7 +504,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call verify
+	call verify@PLT
 	pop %rdx
 	pop %rsi
 	pop %rdi
@@ -544,7 +544,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call verify
+	call verify@PLT
 	pop %rdx
 	pop %rsi
 	pop %rdi
@@ -598,7 +598,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call verify
+	call verify@PLT
 	pop %rdx
 	pop %rsi
 	pop %rdi
@@ -667,7 +667,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call verify_short
+	call verify_short@PLT
 	pop %rdx
 	pop %rsi
 	pop %rdi
@@ -711,7 +711,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -761,7 +761,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -800,7 +800,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -854,7 +854,7 @@ test_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call verify
+	call verify@PLT
 	add $8, %rsp
 	pop %rdx
 	pop %rsi
@@ -897,7 +897,7 @@ test_primitive:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -947,7 +947,7 @@ test_nested:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -972,7 +972,7 @@ test_nested:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1007,7 +1007,7 @@ test_nested:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1042,7 +1042,7 @@ test_nested:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1098,7 +1098,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1137,7 +1137,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1176,7 +1176,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1222,7 +1222,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1260,7 +1260,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1298,7 +1298,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1336,7 +1336,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1384,7 +1384,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1422,7 +1422,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1460,7 +1460,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1498,7 +1498,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1536,7 +1536,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1574,7 +1574,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1620,7 +1620,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1659,7 +1659,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1698,7 +1698,7 @@ test_array_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1739,7 +1739,7 @@ test_struct_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1764,7 +1764,7 @@ test_struct_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1795,7 +1795,7 @@ test_struct_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1827,7 +1827,7 @@ test_struct_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1852,7 +1852,7 @@ test_struct_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1926,7 +1926,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1975,7 +1975,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2024,7 +2024,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2073,7 +2073,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2122,7 +2122,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2171,7 +2171,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2220,7 +2220,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2269,7 +2269,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2318,7 +2318,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2367,7 +2367,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2416,7 +2416,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2465,7 +2465,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2525,7 +2525,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2575,7 +2575,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2610,7 +2610,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2647,7 +2647,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2684,7 +2684,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2721,7 +2721,7 @@ test_complex_designator:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2766,7 +2766,7 @@ test_zero:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2793,7 +2793,7 @@ test_zero:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2826,7 +2826,7 @@ test_zero:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2853,7 +2853,7 @@ test_zero:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2886,7 +2886,7 @@ test_zero:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2913,7 +2913,7 @@ test_zero:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2945,7 +2945,7 @@ test_zero:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2999,7 +2999,7 @@ test_typedef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3032,7 +3032,7 @@ test_typedef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3075,7 +3075,7 @@ test_excessive:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3107,7 +3107,7 @@ test_excessive:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3147,7 +3147,7 @@ test_excessive:
 	pop %rsi
 	pop %rdi
 	mov $0, %eax
-	call strncmp
+	call strncmp@PLT
 	pop %rdx
 	pop %rsi
 	pop %rdi
@@ -3156,7 +3156,7 @@ test_excessive:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3182,41 +3182,41 @@ testmain:
 	lea .L78(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 185 0
 	#     test_string();
-	call test_array
+	call test_array@PLT
 	.loc 2 186 0
 	#     test_struct();
-	call test_string
+	call test_string@PLT
 	.loc 2 187 0
 	#     test_primitive();
-	call test_struct
+	call test_struct@PLT
 	.loc 2 188 0
 	#     test_nested();
-	call test_primitive
+	call test_primitive@PLT
 	.loc 2 189 0
 	#     test_array_designator();
-	call test_nested
+	call test_nested@PLT
 	.loc 2 190 0
 	#     test_struct_designator();
-	call test_array_designator
+	call test_array_designator@PLT
 	.loc 2 191 0
 	#     test_complex_designator();
-	call test_struct_designator
+	call test_struct_designator@PLT
 	.loc 2 192 0
 	#     test_zero();
-	call test_complex_designator
+	call test_complex_designator@PLT
 	.loc 2 193 0
 	#     test_typedef();
-	call test_zero
+	call test_zero@PLT
 	.loc 2 194 0
 	#     test_excessive();
-	call test_typedef
+	call test_typedef@PLT
 	.loc 2 195 0
 	# }
-	call test_excessive
+	call test_excessive@PLT
 	leave
 	ret

--- a/spec/targets/int.s
+++ b/spec/targets/int.s
@@ -211,7 +211,7 @@ expects:
 	mov $1, %rax
 	push %rax
 	pop %rdi
-	call exit
+	call exit@PLT
 	add $8, %rsp
 	pop %rdi
 	.L0:
@@ -237,7 +237,7 @@ testmain:
 	lea .L3(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 16 0
@@ -275,7 +275,7 @@ testmain:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call expects
+	call expects@PLT
 	pop %rsi
 	pop %rdi
 	.loc 2 19 0
@@ -300,7 +300,7 @@ testmain:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call expects
+	call expects@PLT
 	pop %rsi
 	pop %rdi
 	.loc 2 21 0
@@ -339,7 +339,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpectl
+	call fexpectl@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -376,7 +376,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpectl
+	call fexpectl@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -403,7 +403,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpectl
+	call fexpectl@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -428,7 +428,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpectl
+	call fexpectl@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -453,7 +453,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpectl
+	call fexpectl@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -484,7 +484,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpectl
+	call fexpectl@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/iso646.s
+++ b/spec/targets/iso646.s
@@ -142,7 +142,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.file 3 "/home/vagrant/rucc/spec/targets/test.h"
@@ -176,7 +176,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -209,7 +209,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -242,7 +242,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -275,7 +275,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -308,7 +308,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -341,7 +341,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -374,7 +374,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -407,7 +407,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -440,7 +440,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -473,7 +473,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -506,7 +506,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/lex.s
+++ b/spec/targets/lex.s
@@ -161,7 +161,7 @@ digraph:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -194,7 +194,7 @@ digraph:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -227,7 +227,7 @@ digraph:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -260,7 +260,7 @@ digraph:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -293,7 +293,7 @@ digraph:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -326,7 +326,7 @@ digraph:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -359,7 +359,7 @@ digraph:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -392,7 +392,7 @@ digraph:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -419,7 +419,7 @@ digraph:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -462,7 +462,7 @@ escape:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -499,7 +499,7 @@ escape:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -544,7 +544,7 @@ whitespace:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -596,7 +596,7 @@ dollar:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -630,7 +630,7 @@ dollar:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -664,7 +664,7 @@ dollar:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -691,23 +691,23 @@ testmain:
 	lea .L35(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 57 0
 	#     escape();
-	call digraph
+	call digraph@PLT
 	.loc 2 58 0
 	#     whitespace();
-	call escape
+	call escape@PLT
 	.loc 2 59 0
 	#     newline();
-	call whitespace
+	call whitespace@PLT
 	.loc 2 60 0
 	#     dollar();
-	call newline
+	call newline@PLT
 	.loc 2 61 0
 	# }
-	call dollar
+	call dollar@PLT
 	leave
 	ret

--- a/spec/targets/line.s
+++ b/spec/targets/line.s
@@ -142,7 +142,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.file 4 "/home/vagrant/rucc/spec/targets/test.h"
@@ -168,7 +168,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -193,7 +193,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -228,7 +228,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -255,7 +255,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -280,7 +280,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -315,7 +315,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -342,7 +342,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -377,7 +377,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -404,7 +404,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -439,7 +439,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/literal.s
+++ b/spec/targets/literal.s
@@ -153,7 +153,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -178,7 +178,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -203,7 +203,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -228,7 +228,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -253,7 +253,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -278,7 +278,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -303,7 +303,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -328,7 +328,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -353,7 +353,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -378,7 +378,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -403,7 +403,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -428,7 +428,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -453,7 +453,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -483,7 +483,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -508,7 +508,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -538,7 +538,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -563,7 +563,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -588,7 +588,7 @@ test_char:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -633,7 +633,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -666,7 +666,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -707,7 +707,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -746,7 +746,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -781,7 +781,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -814,7 +814,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -879,7 +879,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -906,7 +906,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -931,7 +931,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -957,7 +957,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -982,7 +982,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1032,7 +1032,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1082,7 +1082,7 @@ test_string:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1118,7 +1118,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1143,7 +1143,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1168,7 +1168,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1193,7 +1193,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1218,7 +1218,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1243,7 +1243,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1268,7 +1268,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1293,7 +1293,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1318,7 +1318,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1343,7 +1343,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1368,7 +1368,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1393,7 +1393,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1418,7 +1418,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1443,7 +1443,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1468,7 +1468,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1508,7 +1508,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call memcmp
+	call memcmp@PLT
 	pop %rdx
 	pop %rsi
 	pop %rdi
@@ -1517,7 +1517,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1557,7 +1557,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call memcmp
+	call memcmp@PLT
 	pop %rdx
 	pop %rsi
 	pop %rdi
@@ -1566,7 +1566,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1606,7 +1606,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call memcmp
+	call memcmp@PLT
 	pop %rdx
 	pop %rsi
 	pop %rdi
@@ -1615,7 +1615,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1640,7 +1640,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1680,7 +1680,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call memcmp
+	call memcmp@PLT
 	pop %rdx
 	pop %rsi
 	pop %rdi
@@ -1689,7 +1689,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1714,7 +1714,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1754,7 +1754,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call memcmp
+	call memcmp@PLT
 	pop %rdx
 	pop %rsi
 	pop %rdi
@@ -1763,7 +1763,7 @@ test_mbstring:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1814,7 +1814,7 @@ test_float:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1855,7 +1855,7 @@ test_float:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1898,7 +1898,7 @@ test_float:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1939,7 +1939,7 @@ test_float:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1976,7 +1976,7 @@ test_ucn:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2001,7 +2001,7 @@ test_ucn:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2036,7 +2036,7 @@ test_ucn:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2069,7 +2069,7 @@ test_ucn:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2096,7 +2096,7 @@ test_ucn:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2121,7 +2121,7 @@ test_ucn:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2147,7 +2147,7 @@ test_ucn:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2228,7 +2228,7 @@ test_compound:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2268,7 +2268,7 @@ test_compound:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2295,7 +2295,7 @@ test_compound:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2335,7 +2335,7 @@ test_compound:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2364,7 +2364,7 @@ test_compound:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2397,7 +2397,7 @@ test_compound:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2429,7 +2429,7 @@ test_compound:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2462,7 +2462,7 @@ test_compound:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2507,7 +2507,7 @@ test_compound:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2550,7 +2550,7 @@ test_compound:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2577,26 +2577,26 @@ testmain:
 	lea .L119(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 123 0
 	#     test_string();
-	call test_char
+	call test_char@PLT
 	.loc 2 124 0
 	#     test_mbstring();
-	call test_string
+	call test_string@PLT
 	.loc 2 125 0
 	#     test_float();
-	call test_mbstring
+	call test_mbstring@PLT
 	.loc 2 126 0
 	#     test_ucn();
-	call test_float
+	call test_float@PLT
 	.loc 2 127 0
 	#     test_compound();
-	call test_ucn
+	call test_ucn@PLT
 	.loc 2 128 0
 	# }
-	call test_compound
+	call test_compound@PLT
 	leave
 	ret

--- a/spec/targets/macro.s
+++ b/spec/targets/macro.s
@@ -429,7 +429,7 @@ get_timestamp:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call stat
+	call stat@PLT
 	pop %rsi
 	pop %rdi
 	.loc 4 15 0
@@ -446,7 +446,7 @@ get_timestamp:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call setlocale
+	call setlocale@PLT
 	pop %rsi
 	pop %rdi
 	.loc 4 16 0
@@ -476,14 +476,14 @@ get_timestamp:
 	add $0, %rax
 	push %rax
 	pop %rdi
-	call localtime
+	call localtime@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call strftime
+	call strftime@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -535,7 +535,7 @@ special:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -562,7 +562,7 @@ special:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -589,14 +589,14 @@ special:
 	lea .L8(%rip), %rax
 	push %rax
 	pop %rdi
-	call strlen
+	call strlen@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -621,7 +621,7 @@ special:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -656,7 +656,7 @@ special:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -700,7 +700,7 @@ include:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -733,7 +733,7 @@ include:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -769,7 +769,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -794,7 +794,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -819,7 +819,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -844,7 +844,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -869,7 +869,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -894,7 +894,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -919,7 +919,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -944,7 +944,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -969,7 +969,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -994,7 +994,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1019,7 +1019,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1044,7 +1044,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1069,7 +1069,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1094,7 +1094,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1119,7 +1119,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1144,7 +1144,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1169,7 +1169,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1194,7 +1194,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1219,7 +1219,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1244,7 +1244,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1269,7 +1269,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1294,7 +1294,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1319,7 +1319,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1344,7 +1344,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1369,7 +1369,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1394,7 +1394,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1419,7 +1419,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1444,7 +1444,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1469,7 +1469,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1494,7 +1494,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1519,7 +1519,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1544,7 +1544,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1569,7 +1569,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1594,7 +1594,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1619,7 +1619,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1644,7 +1644,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1669,7 +1669,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1694,7 +1694,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1719,7 +1719,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1744,7 +1744,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1769,7 +1769,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1794,7 +1794,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1819,7 +1819,7 @@ predefined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1855,7 +1855,7 @@ simple:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1885,7 +1885,7 @@ simple:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1930,7 +1930,7 @@ loop:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1959,7 +1959,7 @@ loop:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2000,7 +2000,7 @@ undef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2029,7 +2029,7 @@ undef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2058,7 +2058,7 @@ undef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2102,7 +2102,7 @@ cond_incl:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2140,7 +2140,7 @@ cond_incl:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2176,7 +2176,7 @@ cond_incl:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2212,7 +2212,7 @@ cond_incl:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2248,7 +2248,7 @@ cond_incl:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2284,7 +2284,7 @@ cond_incl:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2320,7 +2320,7 @@ cond_incl:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2356,7 +2356,7 @@ cond_incl:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2405,7 +2405,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2441,7 +2441,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2477,7 +2477,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2513,7 +2513,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2549,7 +2549,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2585,7 +2585,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2621,7 +2621,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2657,7 +2657,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2693,7 +2693,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2729,7 +2729,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2765,7 +2765,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2801,7 +2801,7 @@ const_expr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2850,7 +2850,7 @@ defined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2886,7 +2886,7 @@ defined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2922,7 +2922,7 @@ defined:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2973,7 +2973,7 @@ ifdef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3011,7 +3011,7 @@ ifdef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3049,7 +3049,7 @@ ifdef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3087,7 +3087,7 @@ ifdef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3179,7 +3179,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3212,7 +3212,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3245,7 +3245,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3278,7 +3278,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3311,7 +3311,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3344,7 +3344,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3377,7 +3377,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3410,7 +3410,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3443,7 +3443,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3476,7 +3476,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3509,7 +3509,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3542,7 +3542,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3575,7 +3575,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3608,7 +3608,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3641,7 +3641,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3674,7 +3674,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3707,7 +3707,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3740,7 +3740,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3773,7 +3773,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3800,7 +3800,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3830,7 +3830,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3858,7 +3858,7 @@ funclike:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call plus
+	call plus@PLT
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
@@ -3867,7 +3867,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3892,7 +3892,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3927,7 +3927,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3957,7 +3957,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3987,7 +3987,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4027,7 +4027,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4067,7 +4067,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4097,7 +4097,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4130,7 +4130,7 @@ funclike:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call plus
+	call plus@PLT
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
@@ -4139,7 +4139,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4173,7 +4173,7 @@ funclike:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call plus
+	call plus@PLT
 	pop %rsi
 	pop %rdi
 	mov %rax, %rcx
@@ -4184,7 +4184,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4212,7 +4212,7 @@ funclike:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call plus
+	call plus@PLT
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
@@ -4221,7 +4221,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4249,7 +4249,7 @@ funclike:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call minus
+	call minus@PLT
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
@@ -4258,7 +4258,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4288,7 +4288,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4318,7 +4318,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4343,7 +4343,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4373,7 +4373,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4415,7 +4415,7 @@ funclike:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -4443,7 +4443,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4468,7 +4468,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4494,7 +4494,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4529,7 +4529,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4562,7 +4562,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4595,7 +4595,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4628,7 +4628,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4660,7 +4660,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4695,7 +4695,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4728,7 +4728,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4760,7 +4760,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4789,7 +4789,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4830,7 +4830,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4865,7 +4865,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4898,7 +4898,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4931,7 +4931,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4964,7 +4964,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -4997,7 +4997,7 @@ funclike:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5033,7 +5033,7 @@ empty:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5058,7 +5058,7 @@ empty:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5083,7 +5083,7 @@ empty:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5108,7 +5108,7 @@ empty:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5144,7 +5144,7 @@ noarg:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5189,7 +5189,7 @@ counter:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5214,7 +5214,7 @@ counter:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5239,7 +5239,7 @@ counter:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5283,7 +5283,7 @@ gnuext:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5316,7 +5316,7 @@ gnuext:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5349,7 +5349,7 @@ gnuext:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5382,7 +5382,7 @@ gnuext:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5415,7 +5415,7 @@ gnuext:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -5441,56 +5441,56 @@ testmain:
 	lea .L237(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 4 496 0
 	#     include();
-	call special
+	call special@PLT
 	.loc 4 497 0
 	#     predefined();
-	call include
+	call include@PLT
 	.loc 4 498 0
 	#     simple();
-	call predefined
+	call predefined@PLT
 	.loc 4 499 0
 	#     loop();
-	call simple
+	call simple@PLT
 	.loc 4 500 0
 	#     undef();
-	call loop
+	call loop@PLT
 	.loc 4 501 0
 	#     cond_incl();
-	call undef
+	call undef@PLT
 	.loc 4 502 0
 	#     const_expr();
-	call cond_incl
+	call cond_incl@PLT
 	.loc 4 503 0
 	#     defined();
-	call const_expr
+	call const_expr@PLT
 	.loc 4 504 0
 	#     ifdef();
-	call defined
+	call defined@PLT
 	.loc 4 505 0
 	#     funclike();
-	call ifdef
+	call ifdef@PLT
 	.loc 4 506 0
 	#     empty();
-	call funclike
+	call funclike@PLT
 	.loc 4 507 0
 	#     noarg();
-	call empty
+	call empty@PLT
 	.loc 4 508 0
 	#     null();
-	call noarg
+	call noarg@PLT
 	.loc 4 509 0
 	#     counter();
-	call null
+	call null@PLT
 	.loc 4 510 0
 	#     gnuext();
-	call counter
+	call counter@PLT
 	.loc 4 511 0
 	# }
-	call gnuext
+	call gnuext@PLT
 	leave
 	ret

--- a/spec/targets/noreturn.s
+++ b/spec/targets/noreturn.s
@@ -148,7 +148,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	leave

--- a/spec/targets/number.s
+++ b/spec/targets/number.s
@@ -142,7 +142,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.file 3 "/home/vagrant/rucc/spec/targets/test.h"
@@ -168,7 +168,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -193,7 +193,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -218,7 +218,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -243,7 +243,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -268,7 +268,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -293,7 +293,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -318,7 +318,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -343,7 +343,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -368,7 +368,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -393,7 +393,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -418,7 +418,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -443,7 +443,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -468,7 +468,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -493,7 +493,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -533,7 +533,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -569,7 +569,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -608,7 +608,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -636,7 +636,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -661,7 +661,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -686,7 +686,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -711,7 +711,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -736,7 +736,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/oldstyle.s
+++ b/spec/targets/oldstyle.s
@@ -200,7 +200,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.file 3 "/home/vagrant/rucc/spec/targets/test.h"
@@ -222,14 +222,14 @@ testmain:
 	push %rax
 	sub $8, %rsp
 	mov $0, %eax
-	call no_declaration
+	call no_declaration@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -258,7 +258,7 @@ testmain:
 	pop %rsi
 	pop %rdi
 	mov $0, %eax
-	call oldstyle1
+	call oldstyle1@PLT
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
@@ -267,7 +267,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -287,14 +287,14 @@ testmain:
 	mov $4, %rax
 	push %rax
 	sub $8, %rsp
-	call oldstyle2
+	call oldstyle2@PLT
 	add $8, %rsp
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -317,14 +317,14 @@ testmain:
 	mov $5, %rax
 	push %rax
 	pop %rdi
-	call oldstyle3
+	call oldstyle3@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -356,14 +356,14 @@ testmain:
 	movsd (%rsp), %xmm0
 	add $8, %rsp
 	pop %rdi
-	call oldstyle4
+	call oldstyle4@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi

--- a/spec/targets/pointer.s
+++ b/spec/targets/pointer.s
@@ -165,7 +165,7 @@ t1:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -216,7 +216,7 @@ t2:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -275,7 +275,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -339,7 +339,7 @@ t4:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -400,7 +400,7 @@ t5:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -464,7 +464,7 @@ t6:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -497,7 +497,7 @@ t6:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -531,7 +531,7 @@ t6:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -576,7 +576,7 @@ t6:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -650,7 +650,7 @@ t7:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -711,7 +711,7 @@ subtract:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -745,7 +745,7 @@ subtract:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -812,7 +812,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -847,7 +847,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -884,7 +884,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -934,7 +934,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -969,7 +969,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1019,7 +1019,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1054,7 +1054,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1104,7 +1104,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1139,7 +1139,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1189,7 +1189,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1235,7 +1235,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1272,7 +1272,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1322,7 +1322,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1368,7 +1368,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1397,7 +1397,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1424,7 +1424,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1451,7 +1451,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1478,7 +1478,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1505,7 +1505,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1532,7 +1532,7 @@ compare:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1559,35 +1559,35 @@ testmain:
 	lea .L36(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 89 0
 	#     t2();
-	call t1
+	call t1@PLT
 	.loc 2 90 0
 	#     t3();
-	call t2
+	call t2@PLT
 	.loc 2 91 0
 	#     t4();
-	call t3
+	call t3@PLT
 	.loc 2 92 0
 	#     t5();
-	call t4
+	call t4@PLT
 	.loc 2 93 0
 	#     t6();
-	call t5
+	call t5@PLT
 	.loc 2 94 0
 	#     t7();
-	call t6
+	call t6@PLT
 	.loc 2 95 0
 	#     subtract();
-	call t7
+	call t7@PLT
 	.loc 2 96 0
 	#     compare();
-	call subtract
+	call subtract@PLT
 	.loc 2 97 0
 	# }
-	call compare
+	call compare@PLT
 	leave
 	ret

--- a/spec/targets/scope.s
+++ b/spec/targets/scope.s
@@ -142,7 +142,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	pop %rdi
 	.loc 2 8 0
 	#     { int a = 64; }
@@ -176,7 +176,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -212,7 +212,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx

--- a/spec/targets/sizeof.s
+++ b/spec/targets/sizeof.s
@@ -153,7 +153,7 @@ test_primitives:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -178,7 +178,7 @@ test_primitives:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -203,7 +203,7 @@ test_primitives:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -228,7 +228,7 @@ test_primitives:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -253,7 +253,7 @@ test_primitives:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -278,7 +278,7 @@ test_primitives:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -303,7 +303,7 @@ test_primitives:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -328,7 +328,7 @@ test_primitives:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -364,7 +364,7 @@ test_pointers:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -389,7 +389,7 @@ test_pointers:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -414,7 +414,7 @@ test_pointers:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -439,7 +439,7 @@ test_pointers:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -475,7 +475,7 @@ test_unsigned:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -500,7 +500,7 @@ test_unsigned:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -525,7 +525,7 @@ test_unsigned:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -550,7 +550,7 @@ test_unsigned:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -586,7 +586,7 @@ test_literals:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -611,7 +611,7 @@ test_literals:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -636,7 +636,7 @@ test_literals:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -661,7 +661,7 @@ test_literals:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -686,7 +686,7 @@ test_literals:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -711,7 +711,7 @@ test_literals:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -747,7 +747,7 @@ test_arrays:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -772,7 +772,7 @@ test_arrays:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -797,7 +797,7 @@ test_arrays:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -822,7 +822,7 @@ test_arrays:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -864,7 +864,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -897,7 +897,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -922,7 +922,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -947,7 +947,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -972,7 +972,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1001,7 +1001,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1030,7 +1030,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1055,7 +1055,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1080,7 +1080,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1105,7 +1105,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1130,7 +1130,7 @@ test_vars:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1166,7 +1166,7 @@ test_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1191,7 +1191,7 @@ test_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1216,7 +1216,7 @@ test_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1241,7 +1241,7 @@ test_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1266,7 +1266,7 @@ test_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1291,7 +1291,7 @@ test_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1316,7 +1316,7 @@ test_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1356,7 +1356,7 @@ test_constexpr:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1383,32 +1383,32 @@ testmain:
 	lea .L45(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 82 0
 	#     test_pointers();
-	call test_primitives
+	call test_primitives@PLT
 	.loc 2 83 0
 	#     test_unsigned();
-	call test_pointers
+	call test_pointers@PLT
 	.loc 2 84 0
 	#     test_literals();
-	call test_unsigned
+	call test_unsigned@PLT
 	.loc 2 85 0
 	#     test_arrays();
-	call test_literals
+	call test_literals@PLT
 	.loc 2 86 0
 	#     test_vars();
-	call test_arrays
+	call test_arrays@PLT
 	.loc 2 87 0
 	#     test_struct();
-	call test_vars
+	call test_vars@PLT
 	.loc 2 88 0
 	#     test_constexpr();
-	call test_struct
+	call test_struct@PLT
 	.loc 2 89 0
 	# }
-	call test_constexpr
+	call test_constexpr@PLT
 	leave
 	ret

--- a/spec/targets/staticassert.s
+++ b/spec/targets/staticassert.s
@@ -142,7 +142,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 9 0

--- a/spec/targets/stmtexpr.s
+++ b/spec/targets/stmtexpr.s
@@ -142,7 +142,7 @@ testmain:
 	lea .L0(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	pop %rdi
 	.loc 2 8 0
 	#     expectf(3.0, ({ 1; 2; 3.0; }));
@@ -174,7 +174,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -222,7 +222,7 @@ testmain:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -255,7 +255,7 @@ testmain:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx

--- a/spec/targets/struct.s
+++ b/spec/targets/struct.s
@@ -162,7 +162,7 @@ t1:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -218,7 +218,7 @@ t2:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -285,7 +285,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -353,7 +353,7 @@ t4:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -404,7 +404,7 @@ t5:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -458,7 +458,7 @@ t6:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -509,7 +509,7 @@ t7:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -563,7 +563,7 @@ t8:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -630,7 +630,7 @@ t9:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -686,7 +686,7 @@ t9:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -723,7 +723,7 @@ t9:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -790,7 +790,7 @@ t10:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -843,7 +843,7 @@ t11:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -872,7 +872,7 @@ t11:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -902,7 +902,7 @@ t11:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -945,7 +945,7 @@ t11:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -974,7 +974,7 @@ t11:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1004,7 +1004,7 @@ t11:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1081,7 +1081,7 @@ t12:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1142,7 +1142,7 @@ t12:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1203,7 +1203,7 @@ t12:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1250,7 +1250,7 @@ t12:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1292,7 +1292,7 @@ t13:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1345,7 +1345,7 @@ t14:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1405,7 +1405,7 @@ unnamed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1442,7 +1442,7 @@ unnamed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1522,7 +1522,7 @@ assign:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1547,7 +1547,7 @@ assign:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1572,7 +1572,7 @@ assign:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1598,7 +1598,7 @@ assign:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1624,7 +1624,7 @@ assign:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1684,7 +1684,7 @@ arrow:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1714,7 +1714,7 @@ arrow:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1747,7 +1747,7 @@ arrow:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1781,7 +1781,7 @@ arrow:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1849,7 +1849,7 @@ arrow:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1882,7 +1882,7 @@ arrow:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1916,7 +1916,7 @@ arrow:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -1973,7 +1973,7 @@ address:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2004,7 +2004,7 @@ address:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2034,7 +2034,7 @@ address:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2063,7 +2063,7 @@ address:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2113,7 +2113,7 @@ address:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2144,7 +2144,7 @@ address:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2176,7 +2176,7 @@ address:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2209,7 +2209,7 @@ address:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2254,7 +2254,7 @@ incomplete:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2337,7 +2337,7 @@ bitfield_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2370,7 +2370,7 @@ bitfield_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2397,7 +2397,7 @@ bitfield_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2477,7 +2477,7 @@ bitfield_mix:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2510,7 +2510,7 @@ bitfield_mix:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2537,7 +2537,7 @@ bitfield_mix:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2600,7 +2600,7 @@ bitfield_union:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2633,7 +2633,7 @@ bitfield_union:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2666,7 +2666,7 @@ bitfield_union:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -2752,7 +2752,7 @@ bitfield_unnamed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2783,7 +2783,7 @@ bitfield_unnamed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2808,7 +2808,7 @@ bitfield_unnamed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2878,7 +2878,7 @@ bitfield_unnamed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2909,7 +2909,7 @@ bitfield_unnamed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2934,7 +2934,7 @@ bitfield_unnamed:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -2982,7 +2982,7 @@ bitfield_initializer:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3015,7 +3015,7 @@ bitfield_initializer:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3078,7 +3078,7 @@ bitfield_initializer:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3111,7 +3111,7 @@ bitfield_initializer:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3150,7 +3150,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3176,7 +3176,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3211,7 +3211,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3237,7 +3237,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3263,7 +3263,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3289,7 +3289,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3315,7 +3315,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3341,7 +3341,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3367,7 +3367,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3392,7 +3392,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3417,7 +3417,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3442,7 +3442,7 @@ test_offsetof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3481,7 +3481,7 @@ flexible_member:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3510,7 +3510,7 @@ flexible_member:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3539,7 +3539,7 @@ flexible_member:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3588,7 +3588,7 @@ flexible_member:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3623,7 +3623,7 @@ flexible_member:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3658,7 +3658,7 @@ flexible_member:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3693,7 +3693,7 @@ flexible_member:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3729,7 +3729,7 @@ empty_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3754,7 +3754,7 @@ empty_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -3803,7 +3803,7 @@ incdec_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3835,7 +3835,7 @@ incdec_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3876,7 +3876,7 @@ incdec_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3908,7 +3908,7 @@ incdec_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3949,7 +3949,7 @@ incdec_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -3981,7 +3981,7 @@ incdec_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -4020,7 +4020,7 @@ incdec_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -4052,7 +4052,7 @@ incdec_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -4091,7 +4091,7 @@ incdec_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -4123,7 +4123,7 @@ incdec_struct:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -4150,86 +4150,86 @@ testmain:
 	lea .L97(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 335 0
 	#     t2();
-	call t1
+	call t1@PLT
 	.loc 2 336 0
 	#     t3();
-	call t2
+	call t2@PLT
 	.loc 2 337 0
 	#     t4();
-	call t3
+	call t3@PLT
 	.loc 2 338 0
 	#     t5();
-	call t4
+	call t4@PLT
 	.loc 2 339 0
 	#     t6();
-	call t5
+	call t5@PLT
 	.loc 2 340 0
 	#     t7();
-	call t6
+	call t6@PLT
 	.loc 2 341 0
 	#     t8();
-	call t7
+	call t7@PLT
 	.loc 2 342 0
 	#     t9();
-	call t8
+	call t8@PLT
 	.loc 2 343 0
 	#     t10();
-	call t9
+	call t9@PLT
 	.loc 2 344 0
 	#     t11();
-	call t10
+	call t10@PLT
 	.loc 2 345 0
 	#     t12();
-	call t11
+	call t11@PLT
 	.loc 2 346 0
 	#     t13();
-	call t12
+	call t12@PLT
 	.loc 2 347 0
 	#     t14();
-	call t13
+	call t13@PLT
 	.loc 2 348 0
 	#     unnamed();
-	call t14
+	call t14@PLT
 	.loc 2 349 0
 	#     assign();
-	call unnamed
+	call unnamed@PLT
 	.loc 2 350 0
 	#     arrow();
-	call assign
+	call assign@PLT
 	.loc 2 351 0
 	#     incomplete();
-	call arrow
+	call arrow@PLT
 	.loc 2 352 0
 	#     bitfield_basic();
-	call incomplete
+	call incomplete@PLT
 	.loc 2 353 0
 	#     bitfield_mix();
-	call bitfield_basic
+	call bitfield_basic@PLT
 	.loc 2 354 0
 	#     bitfield_union();
-	call bitfield_mix
+	call bitfield_mix@PLT
 	.loc 2 355 0
 	#     bitfield_unnamed();
-	call bitfield_union
+	call bitfield_union@PLT
 	.loc 2 356 0
 	#     bitfield_initializer();
-	call bitfield_unnamed
+	call bitfield_unnamed@PLT
 	.loc 2 357 0
 	#     test_offsetof();
-	call bitfield_initializer
+	call bitfield_initializer@PLT
 	.loc 2 358 0
 	#     flexible_member();
-	call test_offsetof
+	call test_offsetof@PLT
 	.loc 2 359 0
 	#     empty_struct();
-	call flexible_member
+	call flexible_member@PLT
 	.loc 2 360 0
 	# }
-	call empty_struct
+	call empty_struct@PLT
 	leave
 	ret

--- a/spec/targets/testmain.s
+++ b/spec/targets/testmain.s
@@ -487,7 +487,7 @@ print:
 	mov stdout+0(%rip), %rax
 	push %rax
 	pop %rdi
-	call fflush
+	call fflush@PLT
 	pop %rdi
 	leave
 	ret
@@ -510,12 +510,12 @@ printfail:
 	mov stdout+0(%rip), %rax
 	push %rax
 	pop %rdi
-	call fileno
+	call fileno@PLT
 	add $8, %rsp
 	pop %rdi
 	push %rax
 	pop %rdi
-	call isatty
+	call isatty@PLT
 	add $8, %rsp
 	pop %rdi
 	test %rax, %rax
@@ -557,7 +557,7 @@ ffail:
 	.loc 4 34 0
 	#     printf("%s:%d: %s\n", file, line, msg);
 	sub $8, %rsp
-	call printfail
+	call printfail@PLT
 	add $8, %rsp
 	.loc 4 35 0
 	#     exit(1);
@@ -597,7 +597,7 @@ ffail:
 	mov $1, %rax
 	push %rax
 	pop %rdi
-	call exit
+	call exit@PLT
 	pop %rdi
 	leave
 	ret
@@ -633,7 +633,7 @@ fexpect:
 	.L6:
 	.loc 4 42 0
 	#     printf("%s:%d: %d expected, but got %d\n", file, line, a, b);
-	call printfail
+	call printfail@PLT
 	.loc 4 43 0
 	#     exit(1);
 	push %rdi
@@ -678,7 +678,7 @@ fexpect:
 	mov $1, %rax
 	push %rax
 	pop %rdi
-	call exit
+	call exit@PLT
 	add $8, %rsp
 	pop %rdi
 	leave
@@ -707,7 +707,7 @@ fexpect_string:
 	push %rax
 	pop %rsi
 	pop %rdi
-	call strcmp
+	call strcmp@PLT
 	pop %rsi
 	pop %rdi
 	cmp $0, %rax
@@ -722,7 +722,7 @@ fexpect_string:
 	.L8:
 	.loc 4 50 0
 	#     printf("%s:%d: \"%s\" expected, but got \"%s\"\n", file, line, a, b);
-	call printfail
+	call printfail@PLT
 	.loc 4 51 0
 	#     exit(1);
 	push %rdi
@@ -767,7 +767,7 @@ fexpect_string:
 	mov $1, %rax
 	push %rax
 	pop %rdi
-	call exit
+	call exit@PLT
 	add $8, %rsp
 	pop %rdi
 	leave
@@ -808,7 +808,7 @@ fexpectf:
 	.L10:
 	.loc 4 58 0
 	#     printf("%s:%d: %f expected, but got %f\n", file, line, a, b);
-	call printfail
+	call printfail@PLT
 	.loc 4 59 0
 	#     exit(1);
 	push %rdi
@@ -865,7 +865,7 @@ fexpectf:
 	mov $1, %rax
 	push %rax
 	pop %rdi
-	call exit
+	call exit@PLT
 	add $8, %rsp
 	pop %rdi
 	leave
@@ -906,7 +906,7 @@ fexpectd:
 	.L12:
 	.loc 4 66 0
 	#     printf("%s:%d: %lf expected, but got %lf\n", file, line, a, b);
-	call printfail
+	call printfail@PLT
 	.loc 4 67 0
 	#     exit(1);
 	push %rdi
@@ -953,7 +953,7 @@ fexpectd:
 	mov $1, %rax
 	push %rax
 	pop %rdi
-	call exit
+	call exit@PLT
 	add $8, %rsp
 	pop %rdi
 	leave
@@ -990,7 +990,7 @@ fexpectl:
 	.L14:
 	.loc 4 74 0
 	#     printf("%s:%d: %ld expected, but got %ld\n", file, line, a, b);
-	call printfail
+	call printfail@PLT
 	.loc 4 75 0
 	#     exit(1);
 	push %rdi
@@ -1043,7 +1043,7 @@ fexpectl:
 	mov $1, %rax
 	push %rax
 	pop %rdi
-	call exit
+	call exit@PLT
 	add $8, %rsp
 	pop %rdi
 	leave
@@ -1058,7 +1058,7 @@ main:
 	# }
 	.loc 4 80 0
 	#     printf(isatty(fileno(stdout)) ? "\e[32mOK\e[0m\n" : "OK\n");
-	call testmain
+	call testmain@PLT
 	.loc 4 81 0
 	#     return 0;
 	push %rdi
@@ -1072,12 +1072,12 @@ main:
 	mov stdout+0(%rip), %rax
 	push %rax
 	pop %rdi
-	call fileno
+	call fileno@PLT
 	add $8, %rsp
 	pop %rdi
 	push %rax
 	pop %rdi
-	call isatty
+	call isatty@PLT
 	add $8, %rsp
 	pop %rdi
 	test %rax, %rax

--- a/spec/targets/type.s
+++ b/spec/targets/type.s
@@ -270,7 +270,7 @@ test_pointer:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -301,7 +301,7 @@ test_pointer:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -332,7 +332,7 @@ test_pointer:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -385,7 +385,7 @@ test_typedef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -431,7 +431,7 @@ test_typedef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -465,7 +465,7 @@ test_typedef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -499,7 +499,7 @@ test_typedef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -537,7 +537,7 @@ test_typedef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -566,7 +566,7 @@ test_typedef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -595,7 +595,7 @@ test_typedef:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -631,7 +631,7 @@ test_align:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -657,32 +657,32 @@ testmain:
 	lea .L11(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 3 103 0
 	#     test_signed();
-	call test_type
+	call test_type@PLT
 	.loc 3 104 0
 	#     test_unsigned();
-	call test_signed
+	call test_signed@PLT
 	.loc 3 105 0
 	#     test_storage_class();
-	call test_unsigned
+	call test_unsigned@PLT
 	.loc 3 106 0
 	#     test_pointer();
-	call test_storage_class
+	call test_storage_class@PLT
 	.loc 3 107 0
 	#     test_unusual_order();
-	call test_pointer
+	call test_pointer@PLT
 	.loc 3 108 0
 	#     test_typedef();
-	call test_unusual_order
+	call test_unusual_order@PLT
 	.loc 3 109 0
 	#     test_align();
-	call test_typedef
+	call test_typedef@PLT
 	.loc 3 110 0
 	# }
-	call test_align
+	call test_align@PLT
 	leave
 	ret

--- a/spec/targets/typeof.s
+++ b/spec/targets/typeof.s
@@ -159,7 +159,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -191,7 +191,7 @@ test_basic:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -247,7 +247,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -276,7 +276,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -313,7 +313,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -350,7 +350,7 @@ test_array:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -395,7 +395,7 @@ test_alt:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -422,17 +422,17 @@ testmain:
 	lea .L8(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 33 0
 	#     test_array();
-	call test_basic
+	call test_basic@PLT
 	.loc 2 34 0
 	#     test_alt();
-	call test_array
+	call test_array@PLT
 	.loc 2 35 0
 	# }
-	call test_alt
+	call test_alt@PLT
 	leave
 	ret

--- a/spec/targets/union.s
+++ b/spec/targets/union.s
@@ -162,7 +162,7 @@ t1:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -225,7 +225,7 @@ t2:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -345,7 +345,7 @@ t3:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	add $8, %rsp
 	pop %rcx
 	pop %rdx
@@ -382,7 +382,7 @@ test_sizeof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -407,7 +407,7 @@ test_sizeof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -432,7 +432,7 @@ test_sizeof:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -458,20 +458,20 @@ testmain:
 	lea .L6(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 33 0
 	#     t2();
-	call t1
+	call t1@PLT
 	.loc 2 34 0
 	#     t3();
-	call t2
+	call t2@PLT
 	.loc 2 35 0
 	#     test_sizeof();
-	call t3
+	call t3@PLT
 	.loc 2 36 0
 	# }
-	call test_sizeof
+	call test_sizeof@PLT
 	leave
 	ret

--- a/spec/targets/usualconv.s
+++ b/spec/targets/usualconv.s
@@ -153,7 +153,7 @@ test_usual_conv:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -178,7 +178,7 @@ test_usual_conv:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -203,7 +203,7 @@ test_usual_conv:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -228,7 +228,7 @@ test_usual_conv:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -253,7 +253,7 @@ test_usual_conv:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -278,7 +278,7 @@ test_usual_conv:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -303,7 +303,7 @@ test_usual_conv:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -328,7 +328,7 @@ test_usual_conv:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -354,11 +354,11 @@ testmain:
 	lea .L8(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 20 0
 	# }
-	call test_usual_conv
+	call test_usual_conv@PLT
 	leave
 	ret

--- a/spec/targets/varargs.s
+++ b/spec/targets/varargs.s
@@ -153,7 +153,7 @@ test_builtin:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -178,7 +178,7 @@ test_builtin:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -203,7 +203,7 @@ test_builtin:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -271,7 +271,7 @@ test_int:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -321,7 +321,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L6
 	.L5:
@@ -346,7 +346,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L8
 	.L7:
@@ -358,7 +358,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L8:
 	.L6:
@@ -369,7 +369,7 @@ test_int:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -419,7 +419,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L11
 	.L10:
@@ -444,7 +444,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L13
 	.L12:
@@ -456,7 +456,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L13:
 	.L11:
@@ -467,7 +467,7 @@ test_int:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -517,7 +517,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L16
 	.L15:
@@ -542,7 +542,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L18
 	.L17:
@@ -554,7 +554,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L18:
 	.L16:
@@ -565,7 +565,7 @@ test_int:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -615,7 +615,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L21
 	.L20:
@@ -640,7 +640,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L23
 	.L22:
@@ -652,7 +652,7 @@ test_int:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L23:
 	.L21:
@@ -663,7 +663,7 @@ test_int:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -742,7 +742,7 @@ test_float:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectf
+	call fexpectf@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -797,7 +797,7 @@ test_float:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L29
 	.L28:
@@ -822,7 +822,7 @@ test_float:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L31
 	.L30:
@@ -834,7 +834,7 @@ test_float:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L31:
 	.L29:
@@ -847,7 +847,7 @@ test_float:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -902,7 +902,7 @@ test_float:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L35
 	.L34:
@@ -927,7 +927,7 @@ test_float:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L37
 	.L36:
@@ -939,7 +939,7 @@ test_float:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L37:
 	.L35:
@@ -952,7 +952,7 @@ test_float:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -1007,7 +1007,7 @@ test_float:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L41
 	.L40:
@@ -1032,7 +1032,7 @@ test_float:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L43
 	.L42:
@@ -1044,7 +1044,7 @@ test_float:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L43:
 	.L41:
@@ -1057,7 +1057,7 @@ test_float:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rsi
@@ -1130,7 +1130,7 @@ test_mix:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1186,7 +1186,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L49
 	.L48:
@@ -1211,7 +1211,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L51
 	.L50:
@@ -1223,7 +1223,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L51:
 	.L49:
@@ -1236,7 +1236,7 @@ test_mix:
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
-	call fexpectd
+	call fexpectd@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm1
 	add $8, %rsp
@@ -1287,7 +1287,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L54
 	.L53:
@@ -1312,7 +1312,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L56
 	.L55:
@@ -1324,7 +1324,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L56:
 	.L54:
@@ -1335,7 +1335,7 @@ test_mix:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1389,7 +1389,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L60
 	.L59:
@@ -1414,7 +1414,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L62
 	.L61:
@@ -1426,7 +1426,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L62:
 	.L60:
@@ -1436,7 +1436,7 @@ test_mix:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1486,7 +1486,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_gp
+	call __va_arg_gp@PLT
 	pop %rdi
 	jmp .L65
 	.L64:
@@ -1511,7 +1511,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_fp
+	call __va_arg_fp@PLT
 	pop %rdi
 	jmp .L67
 	.L66:
@@ -1523,7 +1523,7 @@ test_mix:
 	lea -208(%rbp), %rax
 	push %rax
 	pop %rdi
-	call __va_arg_mem
+	call __va_arg_mem@PLT
 	pop %rdi
 	.L67:
 	.L65:
@@ -1534,7 +1534,7 @@ test_mix:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect
+	call fexpect@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1607,7 +1607,7 @@ fmt:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call vsprintf
+	call vsprintf@PLT
 	add $8, %rsp
 	pop %rdx
 	pop %rsi
@@ -1660,14 +1660,14 @@ test_va_list:
 	push %rax
 	pop %rdi
 	mov $0, %eax
-	call fmt
+	call fmt@PLT
 	pop %rdi
 	push %rax
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1704,7 +1704,7 @@ test_va_list:
 	pop %rsi
 	pop %rdi
 	mov $0, %eax
-	call fmt
+	call fmt@PLT
 	add $8, %rsp
 	pop %rsi
 	pop %rdi
@@ -1713,7 +1713,7 @@ test_va_list:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1781,7 +1781,7 @@ test_va_list:
 	pop %rsi
 	pop %rdi
 	mov $2, %eax
-	call fmt
+	call fmt@PLT
 	movsd (%rsp), %xmm1
 	add $8, %rsp
 	pop %rcx
@@ -1793,7 +1793,7 @@ test_va_list:
 	pop %rdx
 	pop %rsi
 	pop %rdi
-	call fexpect_string
+	call fexpect_string@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
@@ -1819,12 +1819,12 @@ testmain:
 	lea .L80(%rip), %rax
 	push %rax
 	pop %rdi
-	call print
+	call print@PLT
 	add $8, %rsp
 	pop %rdi
 	.loc 2 63 0
 	#     test_int(1, 2, 3, 5, 8);
-	call test_builtin
+	call test_builtin@PLT
 	.loc 2 64 0
 	#     test_float(1.0, 2.0, 4.0, 8.0);
 	push %rdi
@@ -1849,7 +1849,7 @@ testmain:
 	pop %rsi
 	pop %rdi
 	mov $0, %eax
-	call test_int
+	call test_int@PLT
 	add $8, %rsp
 	pop %r8
 	pop %rcx
@@ -1903,7 +1903,7 @@ testmain:
 	movsd (%rsp), %xmm0
 	add $8, %rsp
 	mov $4, %eax
-	call test_float
+	call test_float@PLT
 	add $8, %rsp
 	movsd (%rsp), %xmm3
 	add $8, %rsp
@@ -1947,13 +1947,13 @@ testmain:
 	pop %rsi
 	pop %rdi
 	mov $1, %eax
-	call test_mix
+	call test_mix@PLT
 	pop %rcx
 	pop %rdx
 	pop %rsi
 	pop %rdi
 	.loc 2 67 0
 	# }
-	call test_va_list
+	call test_va_list@PLT
 	leave
 	ret


### PR DESCRIPTION
## WHY
Shared library (cf. glibc) should be called with `@PLT`. 

```as
        call    printf
```

```shell
vagrant@vagrant:~$ gcc tmp.s
/usr/bin/ld: /tmp/cc7SGLZT.o: relocation R_X86_64_PC32 against symbol `printf@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
```

## WHAT
Add `@PLT` to label name.
I also add `@PLT` to labels which are not in shared library, but this is not a problem because `collect2` can fix it.